### PR TITLE
Adjust rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM haproxy:2.9.2-alpine3.19
 USER root
 
 ENV HAPROXY_PORT 2375
-ENV EX_APPS_NET "localhost"
+ENV EX_APPS_NET_FOR_HTTPS "localhost"
 
 RUN set -ex; \
     apk add --no-cache \
@@ -21,4 +21,4 @@ COPY --chmod=664 haproxy_ex_apps.cfg /haproxy_ex_apps.cfg
 
 WORKDIR /
 ENTRYPOINT ["/bin/bash", "start.sh"]
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD /healthcheck.sh
+HEALTHCHECK --interval=10s --timeout=10s --retries=9 CMD /healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM haproxy:2.9.2-alpine3.19
 USER root
 
 ENV HAPROXY_PORT 2375
+ENV BIND_ADDRESS *
 ENV EX_APPS_NET_FOR_HTTPS "localhost"
 
 RUN set -ex; \

--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ openssl req -nodes -new -x509 -subj '/CN=*' -sha256 -keyout certs/privkey.pem -o
 ```shell
 cat certs/fullchain.pem certs/privkey.pem | tee certs/cert.pem > /dev/null 2>&1
 ```
+
+## Possible issues
+
+If you encounter AppAPI doesn't work with this Docker Socket Proxy configured - verify if you are not exceeded **error rate limits** that will ban any further requests for **60m**.
+
+> Solution: Restart aa-docker-socket-proxy container (to reset the haproxy stick-table)
+
+It might happen if you actively re-installing/re-enabling ExApps, as these processes have some requests that have to fail with error HTTP response from Docker Engine (e.g. inspect container), which will be counted in stick-table and lead to exceeding **error rate limitations** in our haproxy configuration.

--- a/README.md
+++ b/README.md
@@ -29,17 +29,22 @@ Instead of `some_secure_password` you put your password that later you should pr
 
 ### Docker with TLS
 
+In this case ExApps will only map host's loopback adapter, and will be avalaible to Nextcloud only throw HaProxy.
+
 ```shell
 docker run -e NC_HAPROXY_PASSWORD="some_secure_password" \
+  -e BIND_ADDRESS="x.y.z.z"
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v `pwd`/certs/cert.pem:/certs/cert.pem \
   --name aa-docker-socket-proxy -h aa-docker-socket-proxy --net host \
   --restart unless-stopped --privileged -d ghcr.io/cloud-py-api/aa-docker-socket-proxy:release
 ```
 
-Here in addition we map certificate file from host with SSL certificate that will be used by HaProxy and specify `host` network.
+Here in addition we map certificate file from host with SSL certificate that will be used by HaProxy and specify to use the `host` network.
 
-*In this case ExApps will only map host's loopback adapter, and will be avalaible to Nextcloud only throw HaProxy.*
+You should set `BIND_ADDRESS` to the IP on which server with ExApps can accept requests coming from the Nextcloud instance.
+
+*This is necessary when using the “host” network so as not to occupy all interfaces, because ExApp will use loopback adapter.*
 
 > [!WARNING]
 > If the certificates are self-signed, your job is to add them to the Nextcloud instance so that AppAPI can recognize them.
@@ -52,6 +57,8 @@ Here in addition we map certificate file from host with SSL certificate that wil
 ### Additionally supported variables
 
 `HAPROXY_PORT`: using of custom port instead of **2375** which is the default one.
+
+`BIND_ADDRESS`: the address to use for port binding. (Usually needed only for remote installs, **must be accessible from the Nextcloud**)
 
 `EX_APPS_NET_FOR_HTTPS`: only for custom remote ExApp installs with TLS, determines destination of requests to ExApps for HaProxy.
 
@@ -108,6 +115,7 @@ Create HaProxy container:
 
 ```shell
 docker run -e NC_HAPROXY_PASSWORD="some_secure_password" \
+  -e BIND_ADDRESS="172.17.0.1" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v `pwd`/certs/cert.pem:/certs/cert.pem \
   --name aa-docker-socket-proxy -h aa-docker-socket-proxy --net host \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ docker run -e NC_HAPROXY_PASSWORD="some_secure_password" \
 ```
 
 Here in addition we map certificate file from host with SSL certificate that will be used by HaProxy and specify `host` network.
+
 *In this case ExApps will only map host's loopback adapter, and will be avalaible to Nextcloud only throw HaProxy.*
 
 > [!WARNING]
@@ -76,7 +77,7 @@ docker run -e NC_HAPROXY_PASSWORD="some_secure_password" \
 After that create daemon in AppAPI from the Docker Socket Proxy template, specifying:
 1. Host: `aa-docker-socket-proxy:2375`
 2. Network in Deploy Config equal to `master_default`
-3. HaProxy in Deploy Config password: `some_secure_password`
+3. Deploy Config: HaProxy password: `some_secure_password`
 
 ### HTTPS(remote)
 
@@ -116,4 +117,4 @@ docker run -e NC_HAPROXY_PASSWORD="some_secure_password" \
 After that create daemon in AppAPI from the Docker Socket Proxy template, with next parameters:
 1. Host: `host.docker.internal:2375`
 2. Tick `https` checkbox.
-3. HaProxy in Deploy Config password: `some_secure_password`
+3. Deploy Config: HaProxy password: `some_secure_password`

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -19,7 +19,7 @@ userlist app_api_credentials
 
 frontend docker_engine
     mode http
-    BIND_DOCKER_PLACEHOLDER
+    BIND_ADDRESS_PLACEHOLDER
 
     stick-table type ip size 100k expire 144m store gpc0,http_req_rate(5m)
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -21,16 +21,22 @@ frontend docker_engine
     mode http
     BIND_DOCKER_PLACEHOLDER
 
-    # Rate limiting
-    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(10m)
-    # ACL to restrict rate limited request
-    acl acl-www-err-rate sc_http_err_rate(0) gt 30
+    stick-table type ip size 100k expire 144m store gpc0,http_req_rate(5m)
 
-    http-request track-sc0 src
-    http-request silent-drop if acl-www-err-rate
+    # Perform Basic Auth
+    acl valid_credentials http_auth(app_api_credentials)
 
-    # Basic Authentication
-    http-request auth unless { http_auth(app_api_credentials) }
+    # Increase counter on failed authentication
+    http-request track-sc0 src if ! valid_credentials
+    http-request sc-inc-gpc0(0) if ! valid_credentials
+
+    # Check if the client IP has more than 5 failed attempts in the last 5 minutes
+    acl too_many_auth_failures sc0_http_req_rate gt 5
+
+    # Use 'silent-drop' to drop the connection without a response
+    http-request silent-drop if too_many_auth_failures
+
+    http-request auth realm AppAPI unless valid_credentials
 
     # docker system _ping
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } METH_GET

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -22,13 +22,11 @@ frontend docker_engine
     BIND_DOCKER_PLACEHOLDER
 
     # Rate limiting
-    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(60m)
+    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(10m)
     # ACL to restrict rate limited request
-    acl acl-www-err-rate sc_http_err_rate(0) gt 25
-    acl acl-www-err-total sc_http_err_cnt(0) gt 50
+    acl acl-www-err-rate sc_http_err_rate(0) gt 30
 
     http-request track-sc0 src
-    http-request deny if acl-www-err-total
     http-request silent-drop if acl-www-err-rate
 
     # Basic Authentication

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -24,8 +24,8 @@ frontend docker_engine
     # Rate limiting
     stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(60m)
     # ACL to restrict rate limited request
-    acl acl-www-err-rate sc_http_err_rate(0) gt 5
-    acl acl-www-err-total sc_http_err_cnt(0) gt 10
+    acl acl-www-err-rate sc_http_err_rate(0) gt 25
+    acl acl-www-err-total sc_http_err_cnt(0) gt 50
 
     http-request track-sc0 src
     http-request deny if acl-www-err-total

--- a/haproxy_ex_apps.cfg
+++ b/haproxy_ex_apps.cfg
@@ -3,14 +3,12 @@ frontend ex_apps
     bind *:23000-23999 v4v6 ssl crt /certs/cert.pem
 
     # Rate limiting
-    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(60m)
+    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(10m)
     # ACL to restrict rate limited request
-    acl acl-www-err-rate sc_http_err_rate(0) gt 5
-    acl acl-www-err-total sc_http_err_cnt(0) gt 10
+     acl acl-www-err-rate sc_http_err_rate(0) gt 20
 
-    http-request track-sc0 src
-    http-request deny if acl-www-err-total
-    http-request silent-drop if acl-www-err-rate
+     http-request track-sc0 src
+     http-request silent-drop if acl-www-err-rate
 
     # Basic Authentication
     http-request auth unless { http_auth(app_api_credentials) }
@@ -21,4 +19,4 @@ frontend ex_apps
 
 backend bk_ex_apps
     mode http
-    server ex_apps EX_APPS_NET_PLACEHOLDER
+    server ex_apps EX_APPS_NET_FOR_HTTPS_PLACEHOLDER

--- a/haproxy_ex_apps.cfg
+++ b/haproxy_ex_apps.cfg
@@ -1,6 +1,6 @@
 frontend ex_apps
     mode http
-    bind *:23000-23999 v4v6 ssl crt /certs/cert.pem
+    BIND_ADDRESS_PLACEHOLDER
 
     stick-table type ip size 100k expire 144m store gpc0,http_req_rate(5m)
 

--- a/haproxy_ex_apps.cfg
+++ b/haproxy_ex_apps.cfg
@@ -2,16 +2,22 @@ frontend ex_apps
     mode http
     bind *:23000-23999 v4v6 ssl crt /certs/cert.pem
 
-    # Rate limiting
-    stick-table type ip size 1m expire 1440m store http_err_cnt,http_err_rate(10m)
-    # ACL to restrict rate limited request
-     acl acl-www-err-rate sc_http_err_rate(0) gt 20
+    stick-table type ip size 100k expire 144m store gpc0,http_req_rate(5m)
 
-     http-request track-sc0 src
-     http-request silent-drop if acl-www-err-rate
+    # Perform Basic Auth
+    acl valid_credentials http_auth(app_api_credentials)
 
-    # Basic Authentication
-    http-request auth unless { http_auth(app_api_credentials) }
+    # Increase counter on failed authentication
+    http-request track-sc0 src if ! valid_credentials
+    http-request sc-inc-gpc0(0) if ! valid_credentials
+
+    # Check if the client IP has more than 5 failed attempts in the last 5 minutes
+    acl too_many_auth_failures sc0_http_req_rate gt 5
+
+    # Use 'silent-drop' to drop the connection without a response
+    http-request silent-drop if too_many_auth_failures
+
+    http-request auth realm AppAPI unless valid_credentials
 
     # We allow anything for ExApps
     http-request allow

--- a/start.sh
+++ b/start.sh
@@ -1,23 +1,24 @@
 #!/bin/sh
 
-set -x
-HAPROXYFILE="$(sed "s|NC_PASSWORD_PLACEHOLDER|$NC_HAPROXY_PASSWORD|" /haproxy.cfg)"
-HAPROXYFILE="$(echo "$HAPROXYFILE" | sed "s|HAPROXY_PORT_PLACEHOLDER|$HAPROXY_PORT|")"
+sed -i "s|NC_PASSWORD_PLACEHOLDER|$NC_HAPROXY_PASSWORD|" /haproxy.cfg
 
 if [ -f "/certs/cert.pem" ]; then
-    HAPROXYFILE="$(echo "$HAPROXYFILE" | sed "s|BIND_DOCKER_PLACEHOLDER|bind *:$HAPROXY_PORT v4v6 ssl crt /certs/cert.pem|")"
+    sed -i "s|BIND_ADDRESS_PLACEHOLDER|bind $BIND_ADDRESS:$HAPROXY_PORT v4v6 ssl crt /certs/cert.pem|" /haproxy.cfg
+    sed -i "s|BIND_ADDRESS_PLACEHOLDER|bind $BIND_ADDRESS:23000-23999 v4v6 ssl crt /certs/cert.pem|" /haproxy_ex_apps.cfg
     sed -i "s|EX_APPS_NET_FOR_HTTPS_PLACEHOLDER|$EX_APPS_NET_FOR_HTTPS|" /haproxy_ex_apps.cfg
     # Chmod certs to be accessible by haproxy
     chmod 644 /certs/cert.pem
 else
-    HAPROXYFILE="$(echo "$HAPROXYFILE" | sed "s|BIND_DOCKER_PLACEHOLDER|bind *:$HAPROXY_PORT v4v6|")"
+    sed -i "s|BIND_ADDRESS_PLACEHOLDER|bind $BIND_ADDRESS:$HAPROXY_PORT v4v6|" /haproxy.cfg
 fi
-echo "$HAPROXYFILE" > /haproxy.cfg
 
-set +x
+echo "HaProxy config:"
 
 if [ -f "/certs/cert.pem" ]; then
+  cat /haproxy.cfg
+  cat /haproxy_ex_apps.cfg
   haproxy -f /haproxy.cfg -f /haproxy_ex_apps.cfg -db
 else
+  cat /haproxy.cfg
   haproxy -f /haproxy.cfg -db
 fi

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ HAPROXYFILE="$(echo "$HAPROXYFILE" | sed "s|HAPROXY_PORT_PLACEHOLDER|$HAPROXY_PO
 
 if [ -f "/certs/cert.pem" ]; then
     HAPROXYFILE="$(echo "$HAPROXYFILE" | sed "s|BIND_DOCKER_PLACEHOLDER|bind *:$HAPROXY_PORT v4v6 ssl crt /certs/cert.pem|")"
-    sed -i "s|EX_APPS_NET_PLACEHOLDER|$EX_APPS_NET|" /haproxy_ex_apps.cfg
+    sed -i "s|EX_APPS_NET_FOR_HTTPS_PLACEHOLDER|$EX_APPS_NET_FOR_HTTPS|" /haproxy_ex_apps.cfg
     # Chmod certs to be accessible by haproxy
     chmod 644 /certs/cert.pem
 else

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,7 +5,7 @@ import misc
 
 def test_ping_spam():
     client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
-    for i in range(90):
+    for i in range(100):
         r = client.get("_ping")
         assert r.status_code == 200
 
@@ -23,44 +23,30 @@ def test_volume_creation_removal():
 
 def test_volume_creation_removal_invalid():
     volume_name = "app_test_data"
-    with pytest.raises(httpx.ReadTimeout):
-        for i in range(20):
-            r = httpx.post(
-                "http://localhost:2375/volumes/create",
-                auth=("app_api_haproxy_user", "some_secure_password"),
-                json={"name": volume_name},
-            )
-            assert r.status_code == 403
-            r = httpx.delete(f"http://localhost:2375/volumes/{volume_name}",
-                             auth=("app_api_haproxy_user", "some_secure_password"))
-            assert r.status_code == 403
-    print("Autoban, invalid volume name(2x):", i + 1)
-    misc.initialize_container()
+    for i in range(30):
+        r = httpx.post(
+            "http://localhost:2375/volumes/create",
+            auth=("app_api_haproxy_user", "some_secure_password"),
+            json={"name": volume_name},
+        )
+        assert r.status_code == 403
+        r = httpx.delete(f"http://localhost:2375/volumes/{volume_name}",
+                         auth=("app_api_haproxy_user", "some_secure_password"))
+        assert r.status_code == 403
 
 
-def test_invalid_auth():
-    r = httpx.get("http://localhost:2375/_ping", auth=("app_api_haproxy_user1", "some_secure_password"))
-    assert r.status_code == 401
-    r = httpx.get("http://localhost:2375/_ping", auth=("app_api_haproxy_user", "some_secure_password1"))
-    assert r.status_code == 401
-    misc.initialize_container()
+def test_invalid_url():
+    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
+    for i in range(50):
+        client.get("_unknown")
 
 
 def test_autoban():
     client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password1"))
     with pytest.raises(httpx.ReadTimeout):
-        for i in range(40):
+        for i in range(10):
             client.get("_ping")
     print("Autoban, invalid auth:", i + 1)
-    misc.initialize_container()
-
-
-def test_autoban_invalid_url():
-    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
-    with pytest.raises((httpx.ReadTimeout, httpx.RemoteProtocolError)):
-        for i in range(40):
-            client.get("_unknown")
-    print("Autoban, invalid url:", i + 1)
     misc.initialize_container()
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,7 +5,7 @@ import misc
 
 def test_ping_spam():
     client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
-    for i in range(60):
+    for i in range(90):
         r = client.get("_ping")
         assert r.status_code == 200
 
@@ -24,7 +24,7 @@ def test_volume_creation_removal():
 def test_volume_creation_removal_invalid():
     volume_name = "app_test_data"
     with pytest.raises(httpx.ReadTimeout):
-        for i in range(9):
+        for i in range(20):
             r = httpx.post(
                 "http://localhost:2375/volumes/create",
                 auth=("app_api_haproxy_user", "some_secure_password"),
@@ -34,7 +34,7 @@ def test_volume_creation_removal_invalid():
             r = httpx.delete(f"http://localhost:2375/volumes/{volume_name}",
                              auth=("app_api_haproxy_user", "some_secure_password"))
             assert r.status_code == 403
-    print("Autoban, invalid volume name:", i + 1)
+    print("Autoban, invalid volume name(2x):", i + 1)
     misc.initialize_container()
 
 
@@ -49,7 +49,7 @@ def test_invalid_auth():
 def test_autoban():
     client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password1"))
     with pytest.raises(httpx.ReadTimeout):
-        for i in range(7):
+        for i in range(40):
             client.get("_ping")
     print("Autoban, invalid auth:", i + 1)
     misc.initialize_container()
@@ -58,7 +58,7 @@ def test_autoban():
 def test_autoban_invalid_url():
     client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
     with pytest.raises((httpx.ReadTimeout, httpx.RemoteProtocolError)):
-        for i in range(11):
+        for i in range(40):
             client.get("_unknown")
     print("Autoban, invalid url:", i + 1)
     misc.initialize_container()


### PR DESCRIPTION
Increase haproxy error rate limits by 5 to mitigate exceeding them during frequent ExApps management actions.

**DO NOT MERGE**: Until latest AppAPI changes tests

- [x] Update tests according to rate limits changes