### PR TITLE
timeouts from 10s to 30s

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -11,8 +11,8 @@ defaults
     option dontlognull
     option redispatch
     timeout connect 10s
-    timeout client 10s
-    timeout server 10s
+    timeout client 30s
+    timeout server 30s
 
 userlist app_api_credentials
     user app_api_haproxy_user insecure-password NC_PASSWORD_PLACEHOLDER


### PR DESCRIPTION
With increased timeouts this does not fail on my home `Unraid` instance.

Without it, `stop` container command(Remove ExApp action) fails every time, what leads to situation where ExApp deleted from Nextcloud, but its container still lives.