### PR TITLE
removed "option redispatch" from cfg

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -9,7 +9,6 @@ defaults
     log global
     option httplog
     option dontlognull
-    option redispatch
     timeout connect 10s
     timeout client 30s
     timeout server 30s


### PR DESCRIPTION
This option is only needed if there are several backend servers, which is not possible in our case.