### PR TITLE
added ability to specify custom HaPRoxy timeouts

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only the latest non beta release version of `app_api` are currently being supported with security updates.
+Only the latest non beta release version of `docker-socket-proxy` are currently being supported with security updates.
 
 ## Reporting a Vulnerability
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV HAPROXY_PORT 2375
 ENV BIND_ADDRESS *
 ENV EX_APPS_NET "localhost"
 ENV EX_APPS_COUNT 50
+ENV TIMEOUT_CONNECT "10s"
+ENV TIMEOUT_CLIENT  "30s"
+ENV TIMEOUT_SERVER  "30s"
 
 RUN set -ex; \
     apk add --no-cache \
@@ -14,7 +17,8 @@ RUN set -ex; \
         bash \
         curl \
         openssl \
-        bind-tools; \
+        bind-tools \
+        nano; \
     chmod -R 777 /tmp
 
 COPY --chmod=775 *.sh /

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ You should set `BIND_ADDRESS` to the IP on which server with ExApps can accept r
 
 `BIND_ADDRESS`: the address to use for port binding. (Usually needed only for remote installs, **must be accessible from the Nextcloud**)
 
+`TIMEOUT_CONNECT`: timeout for connecting to ExApp, default: **10s**
+
+`TIMEOUT_CLIENT`: timeout for NC to start sending request data to the ExApp, default: **30s**
+
+`TIMEOUT_SERVER`: timeout for ExApp to start responding to NC request, default: **30s**
+
 #### Only for ExApp installs with TLS:
 
 * `EX_APPS_NET`: determines destination of requests to ExApps for HaProxy. Default:`localhost`
@@ -147,4 +153,17 @@ specify the EX_APPS_NET variable when creating the container:
 
 ```shell
   -e EX_APPS_NET="ipv4@localhost"
+```
+
+### Slow responding ExApps
+
+Some AI applications may respond **longer** than the standard 30 seconds timeout defined in the `HaProxy` config.
+
+An example of such an application: `context_chat`
+
+For the successful operation of such applications, 
+you can set custom config values through the environment variable during the creation of the DSP container with:
+
+```shell
+  -e TIMEOUT_SERVER="1800s"
 ```

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -9,9 +9,9 @@ defaults
     log global
     option httplog
     option dontlognull
-    timeout connect 10s
-    timeout client 30s
-    timeout server 30s
+    timeout connect TIMEOUT_CONNECT
+    timeout client TIMEOUT_CLIENT
+    timeout server TIMEOUT_SERVER
 
 userlist app_api_credentials
     user app_api_haproxy_user insecure-password NC_PASSWORD_PLACEHOLDER

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 sed -i "s|NC_PASSWORD_PLACEHOLDER|$NC_HAPROXY_PASSWORD|" /haproxy.cfg
+sed -i "s|TIMEOUT_CONNECT|$TIMEOUT_CONNECT|" /haproxy.cfg
+sed -i "s|TIMEOUT_CLIENT|$TIMEOUT_CLIENT|" /haproxy.cfg
+sed -i "s|TIMEOUT_SERVER|$TIMEOUT_SERVER|" /haproxy.cfg
 
 if [ -f "/certs/cert.pem" ]; then
     EX_APPS_COUNT_PADDED=$(printf "%03d" "$EX_APPS_COUNT")


### PR DESCRIPTION
Needed for [context_chat_backend](https://github.com/nextcloud/context_chat_backend) as it sometimes respond longer than 30s on request.