### PR TITLE
HaProxy password: support some special characters

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -14,7 +14,7 @@ defaults
     timeout server TIMEOUT_SERVER
 
 userlist app_api_credentials
-    user app_api_haproxy_user insecure-password NC_PASSWORD_PLACEHOLDER
+    user app_api_haproxy_user insecure-password "NC_PASSWORD_PLACEHOLDER"
 
 frontend docker_engine
     mode http

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -9,12 +9,16 @@ def remove_haproxy():
 
 def start_haproxy(port: int = 2375):
     tag = environ.get("TAG_SUFFIX", "latest")
-    run(f"docker run -e NC_HAPROXY_PASSWORD='some_secure_password' -e HAPROXY_PORT={port} "
-        "-v /var/run/docker.sock:/var/run/docker.sock "
-        f"--name nextcloud-appapi-dsp -h nextcloud-appapi-dsp -p {port}:{port} "
-        f"--rm --privileged -d nextcloud-appapi-dsp:{tag}".split(),
+    run(
+        [
+            "docker", "run", "-e", "NC_HAPROXY_PASSWORD=some secure password", "-e",
+            f"HAPROXY_PORT={port}", "-v", "/var/run/docker.sock:/var/run/docker.sock",
+            "--name", "nextcloud-appapi-dsp", "-h", "nextcloud-appapi-dsp", "-p", f"{port}:{port}",
+            "--rm", "--privileged", "-d", f"nextcloud-appapi-dsp:{tag}"
+        ],
         stdout=DEVNULL,
-        check=True)
+        check=True,
+    )
 
 
 def wait_heartbeat():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,7 @@ import misc
 
 
 def test_ping_spam():
-    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
+    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some secure password"))
     for i in range(100):
         r = client.get("_ping")
         assert r.status_code == 200
@@ -13,7 +13,7 @@ def test_ping_spam():
 def test_volume_creation_removal():
     volume_name = "nc_app_test_data"
     httpx.post("http://localhost:2375/volumes/create",
-               auth=("app_api_haproxy_user", "some_secure_password"),
+               auth=("app_api_haproxy_user", "some secure password"),
                json={"name": volume_name})
     httpx.delete(
         f"http://localhost:2375/volumes/{volume_name}",
@@ -26,23 +26,23 @@ def test_volume_creation_removal_invalid():
     for i in range(30):
         r = httpx.post(
             "http://localhost:2375/volumes/create",
-            auth=("app_api_haproxy_user", "some_secure_password"),
+            auth=("app_api_haproxy_user", "some secure password"),
             json={"name": volume_name},
         )
         assert r.status_code == 403
         r = httpx.delete(f"http://localhost:2375/volumes/{volume_name}",
-                         auth=("app_api_haproxy_user", "some_secure_password"))
+                         auth=("app_api_haproxy_user", "some secure password"))
         assert r.status_code == 403
 
 
 def test_invalid_url():
-    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password"))
+    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some secure password"))
     for i in range(50):
         client.get("_unknown")
 
 
 def test_autoban():
-    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some_secure_password1"))
+    client = httpx.Client(base_url="http://localhost:2375", auth=("app_api_haproxy_user", "some secure password1"))
     with pytest.raises(httpx.ReadTimeout):
         for i in range(10):
             client.get("_ping")
@@ -56,7 +56,7 @@ def test_non_standard_port():
     try:
         misc.start_haproxy(port=12375)
         misc.wait_heartbeat()
-        r = httpx.get("http://localhost:12375/_ping", auth=("app_api_haproxy_user", "some_secure_password"))
+        r = httpx.get("http://localhost:12375/_ping", auth=("app_api_haproxy_user", "some secure password"))
         assert r.status_code == 200
     finally:
         misc.remove_haproxy()


### PR DESCRIPTION
Fixes #24


This will allow `spaces` in the password and some other special symbols too.
This should at least make the situation better than it was.