### PR TITLE
corrected algo for "healthcheck" when HTTPS is used

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -3,5 +3,7 @@
 if [ "$BIND_ADDRESS" != "*" ]; then
 	nc -z "$BIND_ADDRESS" "$HAPROXY_PORT" || exit 1
 else
-	nc -z localhost "$HAPROXY_PORT" || exit 1
+  if ! nc -z "127.0.0.1" "$HAPROXY_PORT" && ! nc -z "::1" "$HAPROXY_PORT"; then
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Should fix #23

There are situations when HaProxy listens only to IPv4 interfaces, and “nc -z localhost” resolves by default to IPv6

Therefore, when `$BIND_ADDRESS=*` - we need to check both addresses, if at least one of them opens port 2375 - we assume that HaProxy is healthy.
