### PR TITLE
feat: replace original Authentication header after HaProxy auth

### DIFF
--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -37,9 +37,6 @@ frontend docker_engine
 
     http-request auth realm AppAPI unless valid_credentials
 
-    # Replace the Authorization header if there is X-Original-Authentication header of the original request
-    http-request set-header Authorization %[req.hdr(X-Original-Authentication)] if { req.hdr(X-Original-Authentication) -m found }
-
     # docker system _ping
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } METH_GET
     # container inspect: GET containers/%s/json

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -37,6 +37,9 @@ frontend docker_engine
 
     http-request auth realm AppAPI unless valid_credentials
 
+    # Replace the Authorization header if there is X-Original-Authentication header of the original request
+    http-request set-header Authorization %[req.hdr(X-Original-Authentication)] if { req.hdr(X-Original-Authentication) -m found }
+
     # docker system _ping
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } METH_GET
     # container inspect: GET containers/%s/json

--- a/haproxy_ex_apps.cfg.template
+++ b/haproxy_ex_apps.cfg.template
@@ -19,8 +19,8 @@ frontend ex_apps
 
     http-request auth realm AppAPI unless valid_credentials
 
-    # Replace the Authorization header if there is X-Original-Authentication header of the original request
-    http-request set-header Authorization %[req.hdr(X-Original-Authentication)] if { req.hdr(X-Original-Authentication) -m found }
+    # Replace the Authorization header if there is X-Original-Authorization header of the original request
+    http-request set-header Authorization %[req.hdr(X-Original-Authorization)] if { req.hdr(X-Original-Authorization) -m found }
 
     # We allow anything for ExApps
     http-request allow

--- a/haproxy_ex_apps.cfg.template
+++ b/haproxy_ex_apps.cfg.template
@@ -19,6 +19,9 @@ frontend ex_apps
 
     http-request auth realm AppAPI unless valid_credentials
 
+    # Replace the Authorization header if there is X-Original-Authentication header of the original request
+    http-request set-header Authorization %[req.hdr(X-Original-Authentication)] if { req.hdr(X-Original-Authentication) -m found }
+
     # We allow anything for ExApps
     http-request allow
     use_backend bk_ex_apps


### PR DESCRIPTION
This is backward compatible change, since AppAPI 3.0.0 we'll save the original request's basic Authentication header to `X-Original-Authentication`, and in Docker Socket Proxy here we replace it to the default Authentication header to pass it further to the service behind HaProxy.